### PR TITLE
feat: disallow duplicate keys in objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Parser for Firebase rules JSON files.
 
-It supersedes [RFC 7159] to allow:
+It supersedes [RFC 7159] with those additions:
 
-- Multi line comments.
-- Single line comments.
-- Multi line string.
+- support multi line ("/* [...] */") and single line ("// [...]") comments;
+- support multi line strings (without escaping the line feed);
+- and disallow duplicate keys in objects.
 
 
 ## Example

--- a/src/firebase-json.pegjs
+++ b/src/firebase-json.pegjs
@@ -98,6 +98,10 @@ object
         var result = {};
 
         [head].concat(tail).forEach(function(element) {
+          if (result.hasOwnProperty(element.name)) {
+            error('"' + element.name + '" occurs multiple times.');
+          }
+
           result[element.name] = element.value;
         });
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -49,6 +49,13 @@ const SINGLE_LINE_COMMENT = `// start
 
 const MULTI_LINE_STRING = '"one\ntwo\nthree"';
 
+const SAME_KEY = `{
+  "foo": 1,
+  "bar": 2,
+  "bar": 3,
+  "baz": 4
+}`
+
 describe('firebase-json', function() {
   const packagePath = path.join(__dirname, '../package.json');
 
@@ -81,6 +88,10 @@ describe('firebase-json', function() {
 
     it('should parse multi line string', function() {
       expect(json.parse(MULTI_LINE_STRING)).to.deep.equal('one\ntwo\nthree');
+    });
+
+    it('should throw on duplicated keys', function() {
+      expect(() => json.parse(SAME_KEY)).to.throw();
     });
 
   });


### PR DESCRIPTION
Firebase doesn’t allow rules with duplicated keys.