### PR TITLE
feat: implement better parsing error message

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -94,6 +94,17 @@ describe('firebase-json', function() {
       expect(() => json.parse(SAME_KEY)).to.throw();
     });
 
+    it('should report the error line and column number', function() {
+      expect(() => json.parse('foo')).to.throw(/Line 1, column 1:/);
+      expect(() => json.parse(`{
+        "foo": 1,
+        "bar": {
+          "baz": 2,
+          "baz": 3
+        }
+      }`)).to.throw(/Line 4, column 11:/);
+    });
+
   });
 
   describe('load', function() {


### PR DESCRIPTION
When parsing fails, the error message displays the line and column of the syntax error in the JSON file.

BREAKING CHANGE: `parse(json)` throws a builtin SyntaxError instead of the Pegjs one. Instead of a location property, the error includes the lineNumber and columnNumber property.