### PR TITLE
fix: disallow multi line object key

### DIFF
--- a/src/firebase-json.pegjs
+++ b/src/firebase-json.pegjs
@@ -112,9 +112,14 @@ object
     { return members !== null ? members: {}; }
 
 member
-  = name:string name_separator value:value {
+  = name:key name_separator value:value {
       return { name: name, value: value };
     }
+
+key
+  = quotation_mark chars:(unescaped / escaped)* quotation_mark {
+    return chars.join("");
+  }
 
 // ----- 5. Arrays -----
 
@@ -168,7 +173,10 @@ string "string"
 char
   = unescaped
   / linefeed
-  / escape
+  / escaped
+
+escaped
+  = escape
     sequence:(
         '"'
       / "\\"

--- a/tests/index.js
+++ b/tests/index.js
@@ -93,6 +93,10 @@ describe('firebase-json', function() {
       expect(() => json.parse(SAME_KEY)).to.throw();
     });
 
+    it('should throw on multiline keys', function() {
+      expect(() => json.parse('{"foo\nbar": 1}')).to.throw();
+    });
+
     it('should report the error line and column number', function() {
       expect(() => json.parse('foo')).to.throw(/Line 1, column 1:/);
       expect(() => json.parse(`{


### PR DESCRIPTION
Stop sharing sharing the same token for object keys and string values. While firebase accepts line feed in string value, it requires all white space to be escaped in object keys.