### PR TITLE
fix: fix ast positions to use 0-indexed column

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ npm install firebase-json
 
     Read the file synchronously and parse its firebase-json encoded content.
 
+- `ast(json: rules): {type: string, expression: object, loc: object}`
+
+   Parse the firebase-json encoded string into an to intermediary AST. It uses
+   the ESTree AST schema and returns an "ExpressionStatement" node.
+
 
 ## Tests
 

--- a/src/firebase-json.pegjs
+++ b/src/firebase-json.pegjs
@@ -47,15 +47,15 @@
     return {
       type: 'ExpressionStatement',
       expression: expression,
-      loc: location()
-    }
+      loc: loc()
+    };
   }
 
   function objectNode(properties) {
     return {
       type: 'ObjectExpression',
       properties: properties == null ? [] : properties,
-      loc: location()
+      loc: loc()
     };
   }
 
@@ -64,7 +64,7 @@
       type: 'Property',
       key: key,
       value: value,
-      loc: location(),
+      loc: loc(),
       kind: 'init'
     };
   }
@@ -73,7 +73,7 @@
     return {
       type: 'ArrayExpression',
       elements: elements == null ? [] : elements,
-      loc: location()
+      loc: loc()
     };
   }
 
@@ -82,7 +82,23 @@
       type: 'Literal',
       value: value,
       raw: text(),
-      loc: location()
+      loc: loc()
+    };
+  }
+  
+  function loc() {
+    const pegLoc = location();
+    
+    return {
+      start: position(pegLoc.start),
+      end: position(pegLoc.end)
+    };
+  }
+  
+  function position(pegPosition) {
+    return {
+      line: pegPosition.line,
+      column: pegPosition.column - 1
     };
   }
 }

--- a/src/firebase-json.pegjs
+++ b/src/firebase-json.pegjs
@@ -42,10 +42,55 @@
 // SOFTWARE.
 // 
 
+{
+  function expressionNode(expression) {
+    return {
+      type: 'ExpressionStatement',
+      expression: expression,
+      loc: location()
+    }
+  }
+
+  function objectNode(properties) {
+    return {
+      type: 'ObjectExpression',
+      properties: properties == null ? [] : properties,
+      loc: location()
+    };
+  }
+
+  function propertyNode(key, value) {
+    return {
+      type: 'Property',
+      key: key,
+      value: value,
+      loc: location(),
+      kind: 'init'
+    };
+  }
+
+  function arrayNode(elements) {
+    return {
+      type: 'ArrayExpression',
+      elements: elements == null ? [] : elements,
+      loc: location()
+    };
+  }
+
+  function literalNode(value) {
+    return {
+      type: 'Literal',
+      value: value,
+      raw: text(),
+      loc: location()
+    };
+  }
+}
+
 // ----- 2. JSON Grammar -----
 
 JSON_text
-  = _ value:value _ { return value; }
+  = _ value:value _ { return expressionNode(value); }
 
 begin_array     = _ "[" _
 begin_object    = _ "{" _
@@ -83,60 +128,67 @@ value
   / number
   / string
 
-false = "false" { return false; }
-null  = "null"  { return null;  }
-true  = "true"  { return true;  }
+false = "false" { return literalNode(false); }
+null  = "null"  { return literalNode(null);  }
+true  = "true"  { return literalNode(true);  }
 
 // ----- 4. Objects -----
 
 object
   = begin_object
-    members:(
-      head:member
-      tail:(value_separator m:member { return m; })*
+    properties:(
+      head:property
+      tail:(value_separator m:property { return m; })*
       {
-        var result = {};
+        const properties = [head].concat(tail);
+        const foundKeys = {};
 
-        [head].concat(tail).forEach(function(element) {
-          if (result.hasOwnProperty(element.name)) {
-            error('"' + element.name + '" occurs multiple times.');
+        properties.forEach(prop => {
+          const name = prop.key.value;
+
+          if (foundKeys[name] === true) {
+            error(`'${name}' occurs multiples times.`);
           }
 
-          result[element.name] = element.value;
+          foundKeys[name] = true;
         });
 
-        return result;
+        return properties;
       }
     )?
     end_object
-    { return members !== null ? members: {}; }
+    { return objectNode(properties); }
 
-member
-  = name:key name_separator value:value {
-      return { name: name, value: value };
+property
+  = key:key name_separator value:value {
+      return propertyNode(key, value);
     }
 
 key
   = quotation_mark chars:(unescaped / escaped)* quotation_mark {
-    return chars.join("");
+    return literalNode(chars.join(""));
   }
 
 // ----- 5. Arrays -----
 
 array
   = begin_array
-    values:(
+    elements:(
       head:value
       tail:(value_separator v:value { return v; })*
-      { return [head].concat(tail); }
+      {
+        return [head].concat(tail);
+      }
     )?
     end_array
-    { return values !== null ? values : []; }
+    { return arrayNode(elements); }
 
 // ----- 6. Numbers -----
 
 number "number"
-  = minus? int frac? exp? { return parseFloat(text()); }
+  = minus? int frac? exp? {
+    return literalNode(parseFloat(text()));
+  }
 
 decimal_point
   = "."
@@ -168,7 +220,7 @@ zero
 // ----- 7. Strings -----
 
 string "string"
-  = quotation_mark chars:char* quotation_mark { return chars.join(""); }
+  = quotation_mark chars:char* quotation_mark { return literalNode(chars.join("")); }
 
 char
   = unescaped

--- a/tests/index.js
+++ b/tests/index.js
@@ -58,6 +58,52 @@ const SAME_KEY = `{
 describe('firebase-json', function() {
   const packagePath = path.join(__dirname, '../package.json');
 
+  describe('ast', function() {
+
+    it('should parse json strings into an ExpressionStatement node', function() {
+      const ast = json.ast('null');
+
+      expect(ast).to.have.property('type', 'ExpressionStatement');
+      expect(ast).to.have.property('expression');
+      expect(ast).to.have.property('loc');
+      expect(ast.loc.start.line).to.equal(1);
+      expect(ast.loc.start.column).to.equal(1);
+      expect(ast.loc.end.line).to.equal(1);
+      expect(ast.loc.end.column).to.equal(5);
+    });
+
+    it('should parse object into an ObjectExpression node', function() {
+      const expr = json.ast('{"foo": 1}').expression;
+
+      expect(expr).to.have.property('type', 'ObjectExpression');
+      expect(expr).to.have.property('properties');
+      expect(expr.properties).to.have.length(1);
+      expect(expr.properties[0]).to.have.property('key');
+      expect(expr.properties[0]).to.have.property('value');
+      expect(expr.properties[0]).to.have.property('kind', 'init');
+    });
+
+    it('should parse array into an ArrayExpression node', function() {
+      const expr = json.ast('[1, 2]').expression;
+
+      expect(expr).to.have.property('type', 'ArrayExpression');
+      expect(expr).to.have.property('elements');
+      expect(expr.elements).to.have.length(2);
+    });
+
+    [1, 2.0, -3, -4.0, 2e100, 'one', true, false, null].forEach(literal => {
+      it(`should parse ${literal} into a Literal node`, function() {
+        const raw = JSON.stringify(literal);
+        const expr = json.ast(raw).expression;
+
+        expect(expr).to.have.property('type', 'Literal');
+        expect(expr).to.have.property('value', literal);
+        expect(expr).to.have.property('raw', raw);
+      });
+    });
+
+  });
+
   describe('parse', function() {
 
     it('should parse plain json', function() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -67,9 +67,9 @@ describe('firebase-json', function() {
       expect(ast).to.have.property('expression');
       expect(ast).to.have.property('loc');
       expect(ast.loc.start.line).to.equal(1);
-      expect(ast.loc.start.column).to.equal(1);
+      expect(ast.loc.start.column).to.equal(0);
       expect(ast.loc.end.line).to.equal(1);
-      expect(ast.loc.end.column).to.equal(5);
+      expect(ast.loc.end.column).to.equal(4);
     });
 
     it('should parse object into an ObjectExpression node', function() {


### PR DESCRIPTION
The grammar convert Pegjs `location()` returned value to one compatible
with ESTree schema; pegjs returns 1-indexed line and column positions where
ESTree schema uses 1-indexed line and 0-indexed column.